### PR TITLE
Add method to add styled runs to a paragraph or document

### DIFF
--- a/src/cmi_docx/document.py
+++ b/src/cmi_docx/document.py
@@ -1,6 +1,7 @@
 """Extends a python-docx Word document with additional functionality."""
 
 import pathlib
+from typing import Any, Collection
 
 from docx import document
 from docx.text import paragraph as docx_paragraph
@@ -117,6 +118,22 @@ class ExtendDocument:
         new_paragraph = self._insert_empty_paragraph(index)
         run = new_paragraph.add_run()
         run.add_picture(str(image_path), width=width, height=height)
+        return new_paragraph
+
+    def add_paragraph_from_runs(
+        self, text: Collection[str], styles: Collection[dict[str, Any]]
+    ) -> docx_paragraph.Paragraph:
+        """Adds styled runs to a paragraph.
+
+        Args:
+            text: The text of the runs.
+            styles: The styles of the runs, see run.ExtendRun.format for more details.
+        """
+        if len(text) != len(styles):
+            raise ValueError("The text and styles must be the same length.")
+
+        new_paragraph = self.document.add_paragraph()
+        paragraph.ExtendParagraph(new_paragraph).add_styled_runs(text, styles)
         return new_paragraph
 
     @property

--- a/src/cmi_docx/paragraph.py
+++ b/src/cmi_docx/paragraph.py
@@ -4,6 +4,7 @@ import bisect
 import dataclasses
 import itertools
 import re
+from typing import Any, Collection
 
 from docx.enum import text
 from docx.text import paragraph as docx_paragraph
@@ -110,6 +111,22 @@ class ExtendParagraph:
 
         for run_find in run_finder:
             run_find.replace(replace)
+
+    def add_styled_runs(
+        self, text: Collection[str], styles: Collection[dict[str, Any]]
+    ) -> None:
+        """Adds styled runs to a paragraph.
+
+        Args:
+            text: The text of the runs.
+            styles: The styles of the runs, see run.ExtendRun.format for more details.
+        """
+        if len(text) != len(styles):
+            raise ValueError("The text and styles must be the same length.")
+
+        for run_text, run_style in zip(text, styles):
+            this_run = self.paragraph.add_run(run_text)
+            run.ExtendRun(this_run).format(**run_style)
 
     def format(
         self,

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -117,3 +117,31 @@ def test_insert_paragraph_by_text() -> None:
     assert doc.paragraphs[0].text == "Hello, world!"
     assert doc.paragraphs[1].text == "Maintain, world!"
     assert doc.paragraphs[2].text == "Goodbye, world!"
+
+
+def test_add_paragraph_from_runs() -> None:
+    """Test adding styled runs to a paragraph."""
+    doc = docx.Document()
+    extend_document = document.ExtendDocument(doc)
+
+    text = ["Hello ", "world!"]
+    styles = [{"bold": True}, {"bold": False}]
+
+    new_paragraph = extend_document.add_paragraph_from_runs(text, styles)
+
+    assert len(doc.paragraphs) == 1
+    assert doc.paragraphs[0].text == "Hello world!" == new_paragraph.text
+    assert doc.paragraphs[0].runs[0].bold
+    assert not doc.paragraphs[0].runs[1].bold
+
+
+def test_add_paragraph_from_runs_invalid_length() -> None:
+    """Test adding styled runs to a paragraph with invalid length of text and styles."""
+    doc = docx.Document()
+    extend_document = document.ExtendDocument(doc)
+
+    text = ["Hello", "world!"]
+    styles = [{"bold": True}]
+
+    with pytest.raises(ValueError):
+        extend_document.add_paragraph_from_runs(text, styles)

--- a/tests/test_paragraph.py
+++ b/tests/test_paragraph.py
@@ -86,3 +86,20 @@ def test_replace_multiple_runs(sample_paragraph: docx_paragraph.Paragraph) -> No
         sample_paragraph.text
         == "That was a sample paragraph. That was a sample paragraph."
     )
+
+
+def test_add_styled_runs(sample_paragraph: docx_paragraph.Paragraph) -> None:
+    """Test adding styled runs to a paragraph."""
+    extend_paragraph = paragraph.ExtendParagraph(sample_paragraph)
+    base_runs = len(sample_paragraph.runs)
+
+    text = ["Hello", "World"]
+    styles = [{"bold": True}, {"italics": True, "underline": True}]
+
+    extend_paragraph.add_styled_runs(text, styles)
+
+    assert sample_paragraph.runs[base_runs].text == "Hello"
+    assert sample_paragraph.runs[base_runs].bold
+    assert sample_paragraph.runs[base_runs + 1].text == "World"
+    assert sample_paragraph.runs[base_runs + 1].italic
+    assert sample_paragraph.runs[base_runs + 1].underline


### PR DESCRIPTION
This pull request adds a new method to the `ExtendDocument` and `ExtendParagraph` classes that allows for the addition of styled runs to a paragraph or document. This method takes in a collection of text and styles, and adds the corresponding runs with the specified styles to the paragraph or document. This functionality enhances the flexibility and customization options when working with paragraphs and documents in python-docx.