### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,4 +1,6 @@
 name: Python Tests
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/childmindresearch/cmi-docx/security/code-scanning/4](https://github.com/childmindresearch/cmi-docx/security/code-scanning/4)

To fix the problem, add a `permissions:` block at the root of the workflow file (`.github/workflows/test.yaml`) specifying the least privileges required—for these jobs, this is `contents: read`. This will ensure that the GITHUB_TOKEN available in all jobs has only read access to repository contents, which is sufficient for checking out code and running tests or analysis, but does not allow writing back to the repository. Add the following block directly beneath or above the `on:` key (line 2 or 3), respecting YAML conventions and indentation.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
