### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -7,6 +7,8 @@ on:
 jobs:
   release-build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/childmindresearch/cmi-docx/security/code-scanning/1](https://github.com/childmindresearch/cmi-docx/security/code-scanning/1)

To fix this problem, you should define a least-privilege `permissions` block for the `release-build` job in the workflow. Since the steps in `release-build` only interact with repository contents in a read-only manner (e.g., checking out code, installing/building, and uploading artifact—no pushes, commits, or issue editing), set permissions to `contents: read`. This can be done by adding a `permissions` section under the `release-build` job, mirroring the minimal configuration recommended by CodeQL. Specifically, add the following under line 9, at the same indentation level as `runs-on`.

No other changes, imports, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
